### PR TITLE
Fix HTTP status code question

### DIFF
--- a/src/challenges/02_web-technologies.js
+++ b/src/challenges/02_web-technologies.js
@@ -73,7 +73,7 @@ export default {
 			 `400`,
 			 `500`
 			],
-			solution: `200`,
+			solution: `1`,
 			explanation: `The 200 status codes are reserved for client requests that are
 				received and successfully processed by a server.`
 	  },


### PR DESCRIPTION
The question "Which HTTP status code is reserved for successful responses?" was incorrectly marking every answer as wrong. This pull request fixes that, and marks the correct answer.